### PR TITLE
Service 패키지 이름 수정 및 findAll 함수 재정의

### DIFF
--- a/src/main/java/com/capstone/webserver/subject/api/SubjectController.java
+++ b/src/main/java/com/capstone/webserver/subject/api/SubjectController.java
@@ -4,7 +4,7 @@ import com.capstone.webserver.common.dto.PageRequestDTO;
 import com.capstone.webserver.common.dto.PageResponseDTO;
 import com.capstone.webserver.subject.dto.SubjectDto;
 import com.capstone.webserver.subject.entity.Subject;
-import com.capstone.webserver.subject.srtvice.SubjectService;
+import com.capstone.webserver.subject.service.SubjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/capstone/webserver/subject/repository/SubjectQueryDSLRepository.java
+++ b/src/main/java/com/capstone/webserver/subject/repository/SubjectQueryDSLRepository.java
@@ -37,4 +37,10 @@ public class SubjectQueryDSLRepository extends QuerydslRepositorySupport  {
 
         return new PageImpl<>(subjects, pageable, count);
     }
+
+    public List<Subject> findAll() {
+        return jpaQueryFactory
+                .selectFrom(qSubject)
+                .fetch();
+    }
 }

--- a/src/main/java/com/capstone/webserver/subject/service/SubjectService.java
+++ b/src/main/java/com/capstone/webserver/subject/service/SubjectService.java
@@ -57,7 +57,7 @@ public class SubjectService {
     }
 
     public List<SubjectDto.SubjectResponseDto> findAll() {
-        List<Subject> subjects = subjectRepository.findAll();
+        List<Subject> subjects = subjectQueryDSLRepository.findAll();
         return subjects.stream()
                 .map(this::toSubjectDto)
                 .collect(Collectors.toList());

--- a/src/main/java/com/capstone/webserver/subject/service/SubjectService.java
+++ b/src/main/java/com/capstone/webserver/subject/service/SubjectService.java
@@ -1,4 +1,4 @@
-package com.capstone.webserver.subject.srtvice;
+package com.capstone.webserver.subject.service;
 
 import com.capstone.webserver.common.dto.PageRequestDTO;
 import com.capstone.webserver.common.dto.PageResponseDTO;
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -25,7 +24,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.function.Function;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import static com.capstone.webserver.common.response.exception.ExceptionCode.FILE_NOT_FOUND;


### PR DESCRIPTION
subject에 있는 service 패키지에 오타가 있어서 수정하였습니다.
그리고 팀원분과의 회의로 모든 조회 쿼리는 QueryDSL에서 일어나도록 합의를 봐 기존에 jpaRepository에서 수행되었던 findAll을 QueryDSLRepository에 재정의를 하여 사용하도록 수정하였습니다.